### PR TITLE
program: Add zero-copy struct to represent return data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,6 +2402,8 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "borsh 1.5.1",
+ "bytemuck",
+ "bytemuck_derive",
  "num-derive 0.3.3",
  "num-traits",
  "shank",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,6 +2426,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-vote-program",
+ "spl-pod",
  "thiserror",
 ]
 
@@ -4828,9 +4829,9 @@ dependencies = [
 
 [[package]]
 name = "spl-pod"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6166a591d93af33afd75bbd8573c5fd95fb1213f1bf254f0508c89fdb5ee156"
+checksum = "c704c88fc457fa649ba3aabe195c79d885c3f26709efaddc453c8de352c90b87"
 dependencies = [
  "borsh 1.5.1",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,8 @@ version = "0.0.0"
 dependencies = [
  "assert_matches",
  "borsh 0.10.3",
+ "bytemuck",
+ "bytemuck_derive",
  "num-derive 0.3.3",
  "num-traits",
  "serde",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -13,6 +13,8 @@ serde = ["dep:serde", "dep:serde_with"]
 
 [dependencies]
 borsh = "0.10"
+bytemuck = "1.16"
+bytemuck_derive = "1.7"
 num-derive = "0.3"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -20,6 +20,7 @@ num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_with = { version = "3.0", optional = true }
 solana-program = "2.0"
+spl-pod = "0.3.1"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -3,6 +3,7 @@ mod generated;
 use {
     bytemuck_derive::{Pod, Zeroable},
     solana_program::pubkey::Pubkey,
+    spl_pod::option::PodOption,
 };
 
 pub use generated::programs::SOL_STAKE_VIEW_PROGRAM_ID as ID;
@@ -11,10 +12,21 @@ pub use generated::*;
 /// Helper struct to easily handle the return data created by the
 /// `GetStakeActivatingAndDeactivating` instruction.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 pub struct GetStakeActivatingAndDeactivatingReturnData {
-    pub delegated_vote: Pubkey,
+    pub delegated_vote: PodOption<Pubkey>,
     pub effective: u64,
     pub activating: u64,
     pub deactivating: u64,
+}
+
+impl Default for GetStakeActivatingAndDeactivatingReturnData {
+    fn default() -> Self {
+        Self {
+            delegated_vote: None.try_into().unwrap(),
+            effective: 0,
+            activating: 0,
+            deactivating: 0,
+        }
+    }
 }

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,4 +1,20 @@
 mod generated;
 
+use {
+    bytemuck_derive::{Pod, Zeroable},
+    solana_program::pubkey::Pubkey,
+};
+
 pub use generated::programs::SOL_STAKE_VIEW_PROGRAM_ID as ID;
 pub use generated::*;
+
+/// Helper struct to easily handle the return data created by the
+/// `GetStakeActivatingAndDeactivating` instruction.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct GetStakeActivatingAndDeactivatingReturnData {
+    pub delegated_vote: Pubkey,
+    pub effective: u64,
+    pub activating: u64,
+    pub deactivating: u64,
+}

--- a/clients/rust/tests/get.rs
+++ b/clients/rust/tests/get.rs
@@ -266,7 +266,7 @@ async fn success_activating() {
         paladin_sol_stake_view_program_client::ID
     );
     let expected = GetStakeActivatingAndDeactivatingReturnData {
-        delegated_vote: vote,
+        delegated_vote: Some(vote).try_into().unwrap(),
         activating: stake_amount,
         ..Default::default()
     };
@@ -322,7 +322,7 @@ async fn success_effective() {
         paladin_sol_stake_view_program_client::ID
     );
     let expected = GetStakeActivatingAndDeactivatingReturnData {
-        delegated_vote: vote,
+        delegated_vote: Some(vote).try_into().unwrap(),
         effective: stake_amount,
         ..Default::default()
     };
@@ -380,7 +380,7 @@ async fn success_deactivating() {
         paladin_sol_stake_view_program_client::ID
     );
     let expected = GetStakeActivatingAndDeactivatingReturnData {
-        delegated_vote: vote,
+        delegated_vote: Some(vote).try_into().unwrap(),
         effective: stake_amount,
         deactivating: stake_amount,
         ..Default::default()

--- a/clients/rust/tests/get.rs
+++ b/clients/rust/tests/get.rs
@@ -1,7 +1,10 @@
 #![cfg(feature = "test-sbf")]
 
 use {
-    paladin_sol_stake_view_program_client::instructions::GetStakeActivatingAndDeactivating,
+    paladin_sol_stake_view_program_client::{
+        instructions::GetStakeActivatingAndDeactivating,
+        GetStakeActivatingAndDeactivatingReturnData,
+    },
     solana_program_test::{tokio, ProgramTest, ProgramTestContext},
     solana_sdk::{
         instruction::InstructionError,
@@ -213,7 +216,11 @@ async fn success_undelegated() {
         return_data.program_id,
         paladin_sol_stake_view_program_client::ID
     );
-    assert_eq!(&return_data.data[0..56], [0; 56]);
+    let expected = GetStakeActivatingAndDeactivatingReturnData::default();
+    let returned =
+        bytemuck::try_from_bytes::<GetStakeActivatingAndDeactivatingReturnData>(&return_data.data)
+            .unwrap();
+    assert_eq!(&expected, returned);
 }
 
 #[tokio::test]
@@ -258,19 +265,15 @@ async fn success_activating() {
         return_data.program_id,
         paladin_sol_stake_view_program_client::ID
     );
-    assert_eq!(&return_data.data[0..32], vote.as_ref());
-    assert_eq!(
-        u64::from_le_bytes(return_data.data[32..40].try_into().unwrap()),
-        0
-    );
-    assert_eq!(
-        u64::from_le_bytes(return_data.data[40..48].try_into().unwrap()),
-        stake_amount
-    );
-    assert_eq!(
-        u64::from_le_bytes(return_data.data[48..56].try_into().unwrap()),
-        0
-    );
+    let expected = GetStakeActivatingAndDeactivatingReturnData {
+        delegated_vote: vote,
+        activating: stake_amount,
+        ..Default::default()
+    };
+    let returned =
+        bytemuck::try_from_bytes::<GetStakeActivatingAndDeactivatingReturnData>(&return_data.data)
+            .unwrap();
+    assert_eq!(&expected, returned);
 }
 
 #[tokio::test]
@@ -318,19 +321,15 @@ async fn success_effective() {
         return_data.program_id,
         paladin_sol_stake_view_program_client::ID
     );
-    assert_eq!(&return_data.data[0..32], vote.as_ref());
-    assert_eq!(
-        u64::from_le_bytes(return_data.data[32..40].try_into().unwrap()),
-        stake_amount
-    );
-    assert_eq!(
-        u64::from_le_bytes(return_data.data[40..48].try_into().unwrap()),
-        0
-    );
-    assert_eq!(
-        u64::from_le_bytes(return_data.data[48..56].try_into().unwrap()),
-        0
-    );
+    let expected = GetStakeActivatingAndDeactivatingReturnData {
+        delegated_vote: vote,
+        effective: stake_amount,
+        ..Default::default()
+    };
+    let returned =
+        bytemuck::try_from_bytes::<GetStakeActivatingAndDeactivatingReturnData>(&return_data.data)
+            .unwrap();
+    assert_eq!(&expected, returned);
 }
 
 #[tokio::test]
@@ -380,19 +379,16 @@ async fn success_deactivating() {
         return_data.program_id,
         paladin_sol_stake_view_program_client::ID
     );
-    assert_eq!(&return_data.data[0..32], vote.as_ref());
-    assert_eq!(
-        u64::from_le_bytes(return_data.data[32..40].try_into().unwrap()),
-        stake_amount
-    );
-    assert_eq!(
-        u64::from_le_bytes(return_data.data[40..48].try_into().unwrap()),
-        0
-    );
-    assert_eq!(
-        u64::from_le_bytes(return_data.data[48..56].try_into().unwrap()),
-        stake_amount
-    );
+    let expected = GetStakeActivatingAndDeactivatingReturnData {
+        delegated_vote: vote,
+        effective: stake_amount,
+        deactivating: stake_amount,
+        ..Default::default()
+    };
+    let returned =
+        bytemuck::try_from_bytes::<GetStakeActivatingAndDeactivatingReturnData>(&return_data.data)
+            .unwrap();
+    assert_eq!(&expected, returned);
 }
 
 #[tokio::test]
@@ -445,7 +441,11 @@ async fn success_inactive() {
         return_data.program_id,
         paladin_sol_stake_view_program_client::ID
     );
-    assert_eq!(&return_data.data[0..56], [0; 56]);
+    let expected = GetStakeActivatingAndDeactivatingReturnData::default();
+    let returned =
+        bytemuck::try_from_bytes::<GetStakeActivatingAndDeactivatingReturnData>(&return_data.data)
+            .unwrap();
+    assert_eq!(&expected, returned);
 }
 
 #[tokio::test]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -17,6 +17,8 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 bincode = "1.3.3"
 borsh = "1"
+bytemuck = "1.16"
+bytemuck_derive = "1.7"
 shank = "0.4.2"
 num-derive = "0.3"
 num-traits = "0.2"

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -1,6 +1,5 @@
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    msg, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
 };
 
 use crate::processor;

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,6 +1,6 @@
 use {
     num_derive::{FromPrimitive, ToPrimitive},
-    shank::{ShankContext, ShankInstruction}
+    shank::{ShankContext, ShankInstruction},
 };
 
 #[derive(Clone, Debug, ShankContext, ShankInstruction, FromPrimitive, ToPrimitive)]
@@ -10,7 +10,7 @@ pub enum SolStakeViewInstruction {
     /// delegated to, followed by the effective, activating, and deactivating
     /// SOL stake amount.
     /// Must be a valid SOL stake account.
-    #[account(0, name="stake", desc = "The target SOL stake account")]
-    #[account(1, name="stake_history", desc = "The stake history sysvar")]
+    #[account(0, name = "stake", desc = "The target SOL stake account")]
+    #[account(1, name = "stake_history", desc = "The stake history sysvar")]
     GetStakeActivatingAndDeactivating,
 }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod entrypoint;
 pub mod instruction;
 pub mod processor;
+pub mod state;
 
 pub use solana_program;
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1,5 +1,7 @@
 use {
-    crate::{instruction::SolStakeViewInstruction, state::StakeAmount},
+    crate::{
+        instruction::SolStakeViewInstruction, state::GetStakeActivatingAndDeactivatingReturnData,
+    },
     num_traits::FromPrimitive,
     solana_program::{
         account_info::{next_account_info, AccountInfo},
@@ -45,13 +47,16 @@ fn get_stake_activating_and_deactivating(accounts: &[AccountInfo]) -> ProgramRes
         return Err(ProgramError::InvalidArgument);
     }
 
-    let mut return_data = [0u8; std::mem::size_of::<StakeAmount>()];
+    let mut return_data = [0u8; std::mem::size_of::<GetStakeActivatingAndDeactivatingReturnData>()];
     let stake = try_from_slice_unchecked::<stake::state::StakeStateV2>(&stake_info.data.borrow())?;
 
     // if not delegated, that's fine, all zeros
     if let Some(delegation) = stake.delegation() {
         // safe to unwrap since we created this ourselves
-        let stake_amount = bytemuck::try_from_bytes_mut::<StakeAmount>(&mut return_data).unwrap();
+        let stake_amount = bytemuck::try_from_bytes_mut::<
+            GetStakeActivatingAndDeactivatingReturnData,
+        >(&mut return_data)
+        .unwrap();
         let stake_history = bincode::deserialize(&stake_history_info.data.borrow())
             .map_err(|_| ProgramError::InvalidAccountData)?;
         let current_epoch = Clock::get()?.epoch;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1,9 +1,18 @@
 use {
-    crate::instruction::SolStakeViewInstruction,
+    crate::{instruction::SolStakeViewInstruction, state::StakeAmount},
     num_traits::FromPrimitive,
     solana_program::{
-        account_info::{next_account_info, AccountInfo}, clock::Clock, borsh1::try_from_slice_unchecked, entrypoint::ProgramResult, msg, program_error::ProgramError, pubkey::Pubkey, stake, sysvar::{self, Sysvar}, program::set_return_data,
-    }
+        account_info::{next_account_info, AccountInfo},
+        borsh1::try_from_slice_unchecked,
+        clock::Clock,
+        entrypoint::ProgramResult,
+        msg,
+        program::set_return_data,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        stake,
+        sysvar::{self, Sysvar},
+    },
 };
 
 pub fn process_instruction<'a>(
@@ -14,7 +23,8 @@ pub fn process_instruction<'a>(
     if instruction_data.is_empty() {
         return Err(ProgramError::InvalidArgument);
     }
-    let instruction = SolStakeViewInstruction::from_u8(instruction_data[0]).ok_or(ProgramError::InvalidArgument)?;
+    let instruction = SolStakeViewInstruction::from_u8(instruction_data[0])
+        .ok_or(ProgramError::InvalidArgument)?;
     match instruction {
         SolStakeViewInstruction::GetStakeActivatingAndDeactivating => {
             msg!("Instruction: GetStakeActivatingAndDeactivating");
@@ -22,8 +32,6 @@ pub fn process_instruction<'a>(
         }
     }
 }
-
-const RETURN_DATA_SIZE: usize = 56;
 
 fn get_stake_activating_and_deactivating(accounts: &[AccountInfo]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -37,20 +45,27 @@ fn get_stake_activating_and_deactivating(accounts: &[AccountInfo]) -> ProgramRes
         return Err(ProgramError::InvalidArgument);
     }
 
-    let mut return_data = [0u8; RETURN_DATA_SIZE];
+    let mut return_data = [0u8; std::mem::size_of::<StakeAmount>()];
     let stake = try_from_slice_unchecked::<stake::state::StakeStateV2>(&stake_info.data.borrow())?;
 
     // if not delegated, that's fine, all zeros
     if let Some(delegation) = stake.delegation() {
-        let stake_history = bincode::deserialize(&stake_history_info.data.borrow()).map_err(|_| ProgramError::InvalidAccountData)?;
+        // safe to unwrap since we created this ourselves
+        let stake_amount = bytemuck::try_from_bytes_mut::<StakeAmount>(&mut return_data).unwrap();
+        let stake_history = bincode::deserialize(&stake_history_info.data.borrow())
+            .map_err(|_| ProgramError::InvalidAccountData)?;
         let current_epoch = Clock::get()?.epoch;
-        let stake_activation = delegation.stake_activating_and_deactivating(current_epoch, &stake_history, Some(0));
+        let stake_activation =
+            delegation.stake_activating_and_deactivating(current_epoch, &stake_history, Some(0));
 
-        if stake_activation.effective != 0 || stake_activation.activating != 0 || stake_activation.deactivating != 0 {
-            return_data[0..32].copy_from_slice(delegation.voter_pubkey.as_ref());
-            return_data[32..40].copy_from_slice(&stake_activation.effective.to_le_bytes());
-            return_data[40..48].copy_from_slice(&stake_activation.activating.to_le_bytes());
-            return_data[48..56].copy_from_slice(&stake_activation.deactivating.to_le_bytes());
+        if stake_activation.effective != 0
+            || stake_activation.activating != 0
+            || stake_activation.deactivating != 0
+        {
+            stake_amount.delegated_vote = delegation.voter_pubkey;
+            stake_amount.effective = stake_activation.effective;
+            stake_amount.activating = stake_activation.activating;
+            stake_amount.deactivating = stake_activation.deactivating;
         }
     }
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -5,7 +5,7 @@ use {
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
-pub struct StakeAmount {
+pub struct GetStakeActivatingAndDeactivatingReturnData {
     pub delegated_vote: Pubkey,
     pub effective: u64,
     pub activating: u64,

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1,0 +1,13 @@
+use {
+    bytemuck_derive::{Pod, Zeroable},
+    solana_program::pubkey::Pubkey,
+};
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct StakeAmount {
+    pub delegated_vote: Pubkey,
+    pub effective: u64,
+    pub activating: u64,
+    pub deactivating: u64,
+}


### PR DESCRIPTION
#### Problem

The return data in the program is more confusing than it needs to be, writing to a byte buffer when it can easily be represented through a Pod type, as pointed out in https://github.com/paladin-bladesmith/sol-stake-view-program/pull/1#pullrequestreview-2209592136

#### Solution

Add a zero-copy type called `StakeAmount`, and write to it directly.

Also, since there's no CI on this program yet, I didn't realize that it wasn't running format properly, so I've re-run the formatting step. There weren't a ton of changes, so I hope that's ok!