### PR TITLE
CI: Fixups from failed run

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -61,6 +61,11 @@ runs:
         version: ${{ env.SOLANA_VERSION }}
         cache: true
 
+    - name: Install protoc
+      if: ${{ inputs.solana == 'true' }}
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
     - name: Cache Cargo Dependencies
       if: ${{ inputs.cargo-cache-key && !inputs.cargo-cache-fallback-key }}
       uses: actions/cache@v4

--- a/clients/js/test/noop.test.ts
+++ b/clients/js/test/noop.test.ts
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('there is a test', (t) => {
+  t.is(true, true);
+});


### PR DESCRIPTION
#### Problem

CI is failing at https://github.com/paladin-bladesmith/sol-stake-view-program/actions/runs/10196741143/job/28208255030?pr=6 for a lack of JS tests and https://github.com/paladin-bladesmith/sol-stake-view-program/actions/runs/10196741143/job/28208254707?pr=6 for not installing the protobuf compiler.

#### Summary of Changes

Add an empty JS test, and install the protobuf compiler