### PR TITLE
CI: Add CLI format / lint / test

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -61,8 +61,8 @@ runs:
         version: ${{ env.SOLANA_VERSION }}
         cache: true
 
-    - name: Install protoc
-      if: ${{ inputs.solana == 'true' }}
+    - name: Install protoc and libudev
+      if: ${{ inputs.solana == 'true' || inputs.clippy == 'true' }}
       shell: bash
       run: sudo apt-get update && sudo apt-get install -y libudev-dev protobuf-compiler
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -64,7 +64,7 @@ runs:
     - name: Install protoc
       if: ${{ inputs.solana == 'true' }}
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      run: sudo apt-get update && sudo apt-get install -y libudev-dev protobuf-compiler
 
     - name: Cache Cargo Dependencies
       if: ${{ inputs.cargo-cache-key && !inputs.cargo-cache-fallback-key }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,25 @@ jobs:
       - name: Lint Client Rust
         run: pnpm clients:rust:lint
 
+  format_and_lint_cli:
+    name: Format & Lint CLI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          clippy: true
+          rustfmt: true
+
+      - name: Format CLI
+        run: pnpm clients:cli:format
+
+      - name: Lint CLI
+        run: pnpm clients:cli:lint
+
   build_programs:
     name: Build programs
     runs-on: ubuntu-latest
@@ -196,3 +215,26 @@ jobs:
 
       - name: Test Client Rust
         run: pnpm clients:rust:test
+
+  test_cli:
+    name: Test CLI
+    runs-on: ubuntu-latest
+    needs: build_programs
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-cli
+          solana: true
+
+      - name: Restore Program Builds
+        uses: actions/cache/restore@v4
+        with:
+          path: ./**/*.so
+          key: ${{ runner.os }}-builds-${{ github.sha }}
+
+      - name: Test CLI
+        run: pnpm clients:cli:test

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 license-file = "../../LICENSE"
 
 [features]
-test-sbf = []
 serde = ["dep:serde", "dep:serde_with"]
 
 [dependencies]

--- a/clients/rust/tests/get.rs
+++ b/clients/rust/tests/get.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test-sbf")]
-
 use {
     paladin_sol_stake_view_program_client::{
         instructions::GetStakeActivatingAndDeactivating,

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "clients:js:lint": "zx ./scripts/client/lint-js.mjs",
     "clients:js:publish": "zx ./scripts/client/publish-js.mjs",
     "clients:js:test": "zx ./scripts/client/test-js.mjs",
-    "clients:rust:format": "zx ./scripts/client/format-rust.mjs rust",
-    "clients:rust:lint": "zx ./scripts/client/lint-rust.mjs rust",
-    "clients:rust:test": "zx ./scripts/client/test-rust.mjs rust",
+    "clients:rust:format": "zx ./scripts/client/format-rust.mjs --client-path clients/rust",
+    "clients:rust:lint": "zx ./scripts/client/lint-rust.mjs --client-path clients/rust",
+    "clients:rust:test": "zx ./scripts/client/test-rust.mjs --client-path clients/rust",
     "clients:rust:publish": "zx ./scripts/client/publish-rust.mjs",
-    "clients:cli:format": "zx ./scripts/client/format-rust.mjs cli",
-    "clients:cli:lint": "zx ./scripts/client/lint-rust.mjs cli",
-    "clients:cli:test": "zx ./scripts/client/test-rust.mjs cli"
+    "clients:cli:format": "zx ./scripts/client/format-rust.mjs --client-path clients/cli",
+    "clients:cli:lint": "zx ./scripts/client/lint-rust.mjs --client-path clients/cli",
+    "clients:cli:test": "zx ./scripts/client/test-rust.mjs --client-path clients/cli"
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
     "clients:js:publish": "zx ./scripts/client/publish-js.mjs",
     "clients:js:test": "zx ./scripts/client/test-js.mjs",
     "clients:rust:format": "zx ./scripts/client/format-rust.mjs",
-    "clients:rust:lint": "zx ./scripts/client/lint-rust.mjs",
+    "clients:rust:lint": "zx ./scripts/client/lint-rust.mjs rust",
     "clients:rust:publish": "zx ./scripts/client/publish-rust.mjs",
-    "clients:rust:test": "zx ./scripts/client/test-rust.mjs"
+    "clients:rust:test": "zx ./scripts/client/test-rust.mjs rust",
+    "clients:cli:format": "zx ./scripts/client/format-rust.mjs cli",
+    "clients:cli:lint": "zx ./scripts/client/lint-rust.mjs cli",
+    "clients:cli:test": "zx ./scripts/client/test-rust.mjs cli"
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "clients:js:lint": "zx ./scripts/client/lint-js.mjs",
     "clients:js:publish": "zx ./scripts/client/publish-js.mjs",
     "clients:js:test": "zx ./scripts/client/test-js.mjs",
-    "clients:rust:format": "zx ./scripts/client/format-rust.mjs",
+    "clients:rust:format": "zx ./scripts/client/format-rust.mjs rust",
     "clients:rust:lint": "zx ./scripts/client/lint-rust.mjs rust",
-    "clients:rust:publish": "zx ./scripts/client/publish-rust.mjs",
     "clients:rust:test": "zx ./scripts/client/test-rust.mjs rust",
+    "clients:rust:publish": "zx ./scripts/client/publish-rust.mjs",
     "clients:cli:format": "zx ./scripts/client/format-rust.mjs cli",
     "clients:cli:lint": "zx ./scripts/client/lint-rust.mjs cli",
     "clients:cli:test": "zx ./scripts/client/test-rust.mjs cli"

--- a/scripts/client/format-rust.mjs
+++ b/scripts/client/format-rust.mjs
@@ -4,7 +4,7 @@ import {
   cliArguments,
   getToolchainArgument,
   partitionArguments,
-  popArgument,
+  popFlag,
   workingDirectory,
 } from '../utils.mjs';
 
@@ -14,7 +14,7 @@ const cliArgs = cliArguments();
 const clientPath = cliArgs[0];
 const formatArgs = cliArgs.slice(1);
 
-const fix = popArgument(formatArgs, '--fix');
+const fix = popFlag(formatArgs, '--fix');
 const [cargoArgs, fmtArgs] = partitionArguments(formatArgs, '--');
 const toolchain = getToolchainArgument('format');
 const manifestPath = path.join(

--- a/scripts/client/format-rust.mjs
+++ b/scripts/client/format-rust.mjs
@@ -10,7 +10,9 @@ import {
 
 // Configure additional arguments here, e.g.:
 // ['--arg1', '--arg2', ...cliArguments()]
-const formatArgs = cliArguments();
+const cliArgs = cliArguments();
+const clientPath = cliArgs[0];
+const formatArgs = cliArgs.slice(1);
 
 const fix = popArgument(formatArgs, '--fix');
 const [cargoArgs, fmtArgs] = partitionArguments(formatArgs, '--');
@@ -18,7 +20,7 @@ const toolchain = getToolchainArgument('format');
 const manifestPath = path.join(
   workingDirectory,
   'clients',
-  'rust',
+  clientPath,
   'Cargo.toml'
 );
 

--- a/scripts/client/lint-rust.mjs
+++ b/scripts/client/lint-rust.mjs
@@ -3,7 +3,7 @@ import 'zx/globals';
 import {
   cliArguments,
   getToolchainArgument,
-  popArgument,
+  popFlag,
   workingDirectory,
 } from '../utils.mjs';
 
@@ -19,7 +19,7 @@ const lintArgs = [
   ...cliArgs.slice(1)
 ];
 
-const fix = popArgument(lintArgs, '--fix');
+const fix = popFlag(lintArgs, '--fix');
 const toolchain = getToolchainArgument('format');
 const manifestPath = path.join(
   workingDirectory,

--- a/scripts/client/lint-rust.mjs
+++ b/scripts/client/lint-rust.mjs
@@ -7,13 +7,16 @@ import {
   workingDirectory,
 } from '../utils.mjs';
 
+const cliArgs = cliArguments();
+const clientPath = cliArgs[0];
+
 // Configure additional arguments here, e.g.:
 // ['--arg1', '--arg2', ...cliArguments()]
 const lintArgs = [
   '-Zunstable-options',
   '--',
   '--deny=warnings',
-  ...cliArguments()
+  ...cliArgs.slice(1)
 ];
 
 const fix = popArgument(lintArgs, '--fix');
@@ -21,7 +24,7 @@ const toolchain = getToolchainArgument('format');
 const manifestPath = path.join(
   workingDirectory,
   'clients',
-  'rust',
+  clientPath,
   'Cargo.toml'
 );
 

--- a/scripts/client/lint-rust.mjs
+++ b/scripts/client/lint-rust.mjs
@@ -15,7 +15,7 @@ const lintArgs = [
   '-Zunstable-options',
   '--',
   '--deny=warnings',
-  ...cliArguments()
+  ...cliArguments(),
 ];
 
 const fix = popFlag(lintArgs, '--fix');

--- a/scripts/client/test-rust.mjs
+++ b/scripts/client/test-rust.mjs
@@ -1,6 +1,11 @@
 #!/usr/bin/env zx
 import 'zx/globals';
-import { cliArguments, getAllRustClientFolders, popArgument, workingDirectory } from '../utils.mjs';
+import {
+  cliArguments,
+  getAllRustClientFolders,
+  popArgument,
+  workingDirectory,
+} from '../utils.mjs';
 
 // Configure additional arguments here, e.g.:
 // ['--arg1', '--arg2', ...cliArguments()]

--- a/scripts/client/test-rust.mjs
+++ b/scripts/client/test-rust.mjs
@@ -4,14 +4,17 @@ import { cliArguments, workingDirectory } from '../utils.mjs';
 
 // Configure additional arguments here, e.g.:
 // ['--arg1', '--arg2', ...cliArguments()]
-const testArgs = cliArguments();
+const cliArgs = cliArguments();
+const clientPath = cliArgs[0];
+const testArgs = cliArgs.slice(1);
 
 const hasSolfmt = await which('solfmt', { nothrow: true });
 
 // Run the tests.
-cd(path.join(workingDirectory, 'clients', 'rust'));
+cd(path.join(workingDirectory, 'clients', clientPath));
+const sbfOutDir = path.join(workingDirectory, 'target', 'deploy');
 if (hasSolfmt) {
-  await $`cargo test-sbf ${testArgs} 2>&1 | solfmt`;
+  await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${testArgs} 2>&1 | solfmt`;
 } else {
-  await $`cargo test-sbf ${testArgs}`;
+  await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${testArgs}`;
 }

--- a/scripts/client/test-rust.mjs
+++ b/scripts/client/test-rust.mjs
@@ -1,20 +1,24 @@
 #!/usr/bin/env zx
 import 'zx/globals';
-import { cliArguments, workingDirectory } from '../utils.mjs';
+import { cliArguments, getAllRustClientFolders, popArgument, workingDirectory } from '../utils.mjs';
 
 // Configure additional arguments here, e.g.:
 // ['--arg1', '--arg2', ...cliArguments()]
 const cliArgs = cliArguments();
-const clientPath = cliArgs[0];
-const testArgs = cliArgs.slice(1);
+const clientPath = popArgument(cliArgs, '--client-path');
 
 const hasSolfmt = await which('solfmt', { nothrow: true });
 
 // Run the tests.
-cd(path.join(workingDirectory, 'clients', clientPath));
-const sbfOutDir = path.join(workingDirectory, 'target', 'deploy');
-if (hasSolfmt) {
-  await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${testArgs} 2>&1 | solfmt`;
-} else {
-  await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${testArgs}`;
-}
+const clientFolders = clientPath ? [clientPath] : getAllRustClientFolders();
+await Promise.all(
+  clientFolders.map(async (folder) => {
+    cd(path.join(workingDirectory, folder));
+    const sbfOutDir = path.join(workingDirectory, 'target', 'deploy');
+    if (hasSolfmt) {
+      await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${cliArgs} 2>&1 | solfmt`;
+    } else {
+      await $`SBF_OUT_DIR=${sbfOutDir} cargo test ${cliArgs}`;
+    }
+  })
+);

--- a/scripts/program/format.mjs
+++ b/scripts/program/format.mjs
@@ -5,7 +5,7 @@ import {
   getProgramFolders,
   getToolchainArgument,
   partitionArguments,
-  popArgument,
+  popFlag,
   workingDirectory,
 } from '../utils.mjs';
 
@@ -13,7 +13,7 @@ import {
 // ['--arg1', '--arg2', ...cliArguments()]
 const formatArgs = cliArguments();
 
-const fix = popArgument(formatArgs, '--fix');
+const fix = popFlag(formatArgs, '--fix');
 const [cargoArgs, fmtArgs] = partitionArguments(formatArgs, '--');
 const toolchain = getToolchainArgument('format');
 

--- a/scripts/program/lint.mjs
+++ b/scripts/program/lint.mjs
@@ -4,7 +4,7 @@ import {
   cliArguments,
   getProgramFolders,
   getToolchainArgument,
-  popArgument,
+  popFlag,
   workingDirectory,
 } from '../utils.mjs';
 
@@ -20,7 +20,7 @@ const lintArgs = [
   ...cliArguments()
 ];
 
-const fix = popArgument(lintArgs, '--fix');
+const fix = popFlag(lintArgs, '--fix');
 const toolchain = getToolchainArgument('format');
 
 // Lint the programs using clippy.

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -71,8 +71,8 @@ export function getAllProgramFolders() {
 }
 
 export function getAllRustClientFolders() {
-  return getCargo().workspace.members.filter((member) =>
-    !(getCargo(member).lib?.['crate-type'] ?? []).includes('cdylib'),
+  return getCargo().workspace.members.filter(
+    (member) => !(getCargo(member).lib?.['crate-type'] ?? []).includes('cdylib')
   );
 }
 

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -70,6 +70,12 @@ export function getAllProgramFolders() {
   );
 }
 
+export function getAllRustClientFolders() {
+  return getCargo().workspace.members.filter((member) =>
+    !(getCargo(member).lib?.['crate-type'] ?? []).includes('cdylib'),
+  );
+}
+
 export function getCargo(folder) {
   return parseToml(
     fs.readFileSync(
@@ -107,6 +113,15 @@ export function popFlag(args, arg) {
     args.splice(index, 1);
   }
   return index >= 0;
+}
+
+export function popArgument(args, arg) {
+  const index = args.indexOf(arg);
+  if (index >= 0) {
+    const arg = args.splice(index, 2);
+    return arg[1];
+  }
+  return null;
 }
 
 export function partitionArguments(args, delimiter) {

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -101,7 +101,7 @@ export function cliArguments() {
   return process.argv.slice(3);
 }
 
-export function popArgument(args, arg) {
+export function popFlag(args, arg) {
   const index = args.indexOf(arg);
   if (index >= 0) {
     args.splice(index, 1);


### PR DESCRIPTION
#### Problem

There's a CLI on the program, but there's no working test, and it's not part of CI.

#### Solution

Fixup the CLI test, then add it to CI using the existing Rust client scripts.

Since they look so similar, I updated the lint / format / test scripts to take in the path of the client. I also updated the test to just do `SBF_OUT_DIR=./target/deploy cargo test` rather than `cargo test-sbf`, which does an unnecessary `cargo build-sbf` step.

Let me know what you think! Happy to change up any part of this