### PR TITLE
Make numbers pod-safe

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -4,7 +4,7 @@ pub use generated::{programs::SOL_STAKE_VIEW_PROGRAM_ID as ID, *};
 use {
     bytemuck_derive::{Pod, Zeroable},
     solana_program::pubkey::Pubkey,
-    spl_pod::option::PodOption,
+    spl_pod::{option::PodOption, primitives::PodU64},
 };
 
 /// Helper struct to easily handle the return data created by the
@@ -14,9 +14,9 @@ use {
 pub struct GetStakeActivatingAndDeactivatingReturnData {
     pub withdrawer: PodOption<Pubkey>,
     pub delegated_vote: PodOption<Pubkey>,
-    pub effective: u64,
-    pub activating: u64,
-    pub deactivating: u64,
+    pub effective: PodU64,
+    pub activating: PodU64,
+    pub deactivating: PodU64,
 }
 
 impl Default for GetStakeActivatingAndDeactivatingReturnData {
@@ -24,9 +24,9 @@ impl Default for GetStakeActivatingAndDeactivatingReturnData {
         Self {
             withdrawer: None.try_into().unwrap(),
             delegated_vote: None.try_into().unwrap(),
-            effective: 0,
-            activating: 0,
-            deactivating: 0,
+            effective: 0.into(),
+            activating: 0.into(),
+            deactivating: 0.into(),
         }
     }
 }

--- a/clients/rust/tests/get.rs
+++ b/clients/rust/tests/get.rs
@@ -271,7 +271,7 @@ async fn success_activating() {
     let expected = GetStakeActivatingAndDeactivatingReturnData {
         withdrawer: Some(context.payer.pubkey()).try_into().unwrap(),
         delegated_vote: Some(vote).try_into().unwrap(),
-        activating: stake_amount,
+        activating: stake_amount.into(),
         ..Default::default()
     };
     let returned =
@@ -328,7 +328,7 @@ async fn success_effective() {
     let expected = GetStakeActivatingAndDeactivatingReturnData {
         withdrawer: Some(context.payer.pubkey()).try_into().unwrap(),
         delegated_vote: Some(vote).try_into().unwrap(),
-        effective: stake_amount,
+        effective: stake_amount.into(),
         ..Default::default()
     };
     let returned =
@@ -387,8 +387,8 @@ async fn success_deactivating() {
     let expected = GetStakeActivatingAndDeactivatingReturnData {
         withdrawer: Some(context.payer.pubkey()).try_into().unwrap(),
         delegated_vote: Some(vote).try_into().unwrap(),
-        effective: stake_amount,
-        deactivating: stake_amount,
+        effective: stake_amount.into(),
+        deactivating: stake_amount.into(),
         ..Default::default()
     };
     let returned =

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -46,14 +46,8 @@ fn get_stake_activating_and_deactivating(accounts: &[AccountInfo]) -> ProgramRes
         return Err(ProgramError::InvalidArgument);
     }
 
-    let mut return_data = [0u8; std::mem::size_of::<GetStakeActivatingAndDeactivatingReturnData>()];
+    let mut stake_view = GetStakeActivatingAndDeactivatingReturnData::default();
     let stake = try_from_slice_unchecked::<stake::state::StakeStateV2>(&stake_info.data.borrow())?;
-
-    // safe to unwrap since we created this ourselves
-    let stake_view = bytemuck::try_from_bytes_mut::<GetStakeActivatingAndDeactivatingReturnData>(
-        &mut return_data,
-    )
-    .unwrap();
 
     if let Some(authorized) = stake.authorized() {
         stake_view.withdrawer = authorized.withdrawer;
@@ -78,6 +72,6 @@ fn get_stake_activating_and_deactivating(accounts: &[AccountInfo]) -> ProgramRes
         }
     }
 
-    set_return_data(&return_data);
+    set_return_data(bytemuck::bytes_of(&stake_view));
     Ok(())
 }

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -4,7 +4,7 @@ use {
 };
 
 #[repr(C)]
-#[derive(Copy, Clone, Pod, Zeroable)]
+#[derive(Copy, Clone, Default, Pod, Zeroable)]
 pub struct GetStakeActivatingAndDeactivatingReturnData {
     pub withdrawer: Pubkey,
     pub delegated_vote: Pubkey,


### PR DESCRIPTION
#### Problem

It isn't guaranteed that a caller to `get_return_data` will get the data aligned properly, which can cause issues when trying to read the activation numbers.

#### Solution

Update the client return type to be pod-safe, so that it can work with any alignment.

While looking at this, I decided to go with a safer option for writing the stake data, by instantiating the type, writing to it, then getting its bytes.