### PR TITLE
Return Data: add staker

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -12,6 +12,7 @@ use {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 pub struct GetStakeActivatingAndDeactivatingReturnData {
+    pub staker: PodOption<Pubkey>,
     pub withdrawer: PodOption<Pubkey>,
     pub delegated_vote: PodOption<Pubkey>,
     pub effective: PodU64,
@@ -22,6 +23,7 @@ pub struct GetStakeActivatingAndDeactivatingReturnData {
 impl Default for GetStakeActivatingAndDeactivatingReturnData {
     fn default() -> Self {
         Self {
+            staker: None.try_into().unwrap(),
             withdrawer: None.try_into().unwrap(),
             delegated_vote: None.try_into().unwrap(),
             effective: 0.into(),

--- a/clients/rust/tests/get.rs
+++ b/clients/rust/tests/get.rs
@@ -15,6 +15,7 @@ use {
         vote_instruction,
         vote_state::{VoteInit, VoteState},
     },
+    spl_pod::option::PodOption,
 };
 
 async fn create_vote(
@@ -214,8 +215,10 @@ async fn success_undelegated() {
         return_data.program_id,
         paladin_sol_stake_view_program_client::ID
     );
+    let expected_staker: PodOption<Pubkey> = Some(context.payer.pubkey()).try_into().unwrap();
     let expected = GetStakeActivatingAndDeactivatingReturnData {
-        withdrawer: Some(context.payer.pubkey()).try_into().unwrap(),
+        staker: expected_staker,
+        withdrawer: expected_staker,
         ..Default::default()
     };
     let returned =
@@ -266,8 +269,10 @@ async fn success_activating() {
         return_data.program_id,
         paladin_sol_stake_view_program_client::ID
     );
+    let expected_staker: PodOption<Pubkey> = Some(context.payer.pubkey()).try_into().unwrap();
     let expected = GetStakeActivatingAndDeactivatingReturnData {
-        withdrawer: Some(context.payer.pubkey()).try_into().unwrap(),
+        staker: expected_staker,
+        withdrawer: expected_staker,
         delegated_vote: Some(vote).try_into().unwrap(),
         activating: stake_amount.into(),
         ..Default::default()
@@ -323,8 +328,10 @@ async fn success_effective() {
         return_data.program_id,
         paladin_sol_stake_view_program_client::ID
     );
+    let expected_staker: PodOption<Pubkey> = Some(context.payer.pubkey()).try_into().unwrap();
     let expected = GetStakeActivatingAndDeactivatingReturnData {
-        withdrawer: Some(context.payer.pubkey()).try_into().unwrap(),
+        staker: expected_staker,
+        withdrawer: expected_staker,
         delegated_vote: Some(vote).try_into().unwrap(),
         effective: stake_amount.into(),
         ..Default::default()
@@ -382,8 +389,10 @@ async fn success_deactivating() {
         return_data.program_id,
         paladin_sol_stake_view_program_client::ID
     );
+    let expected_staker: PodOption<Pubkey> = Some(context.payer.pubkey()).try_into().unwrap();
     let expected = GetStakeActivatingAndDeactivatingReturnData {
-        withdrawer: Some(context.payer.pubkey()).try_into().unwrap(),
+        staker: expected_staker,
+        withdrawer: expected_staker,
         delegated_vote: Some(vote).try_into().unwrap(),
         effective: stake_amount.into(),
         deactivating: stake_amount.into(),
@@ -446,6 +455,7 @@ async fn success_inactive() {
         paladin_sol_stake_view_program_client::ID
     );
     let expected = GetStakeActivatingAndDeactivatingReturnData {
+        staker: Some(context.payer.pubkey()).try_into().unwrap(),
         withdrawer: Some(context.payer.pubkey()).try_into().unwrap(),
         ..Default::default()
     };

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -53,6 +53,7 @@ fn get_stake_activating_and_deactivating(accounts: &[AccountInfo]) -> ProgramRes
     let stake = try_from_slice_unchecked::<stake::state::StakeStateV2>(&stake_info.data.borrow())?;
 
     if let Some(authorized) = stake.authorized() {
+        stake_view.staker = authorized.staker;
         stake_view.withdrawer = authorized.withdrawer;
     }
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -6,6 +6,7 @@ use {
 #[repr(C)]
 #[derive(Copy, Clone, Default, Pod, Zeroable)]
 pub struct GetStakeActivatingAndDeactivatingReturnData {
+    pub staker: Pubkey,
     pub withdrawer: Pubkey,
     pub delegated_vote: Pubkey,
     pub effective: u64,


### PR DESCRIPTION
#### Problem
PAL stake accounts are derived from SOL stake accounts, which is representative of the one-to-one relationship between these two types of accounts. Anyone who wishes to query the staker whose funds are staked in both of a given PAL and SOL stake account could simply follow the PAL stake account's pointer to the SOL stake account, then read the staker field from the SOL stake account.

However, if a staker's SOL stake account is closed, even if their PAL account stake is synced, the ability to do this same traversal to find the staker is lost.

Additionally, the withdraw authority may not always indicate the staker, since protocols such as liquid staking tokens (LSTs) may commandeer a stake account's withdraw/stake authority, leaving the "staker" field in-tact.

#### Summary of Changes
Add the `staker` field to the captured SOL stake account data, similar to `withdraw_authority`.